### PR TITLE
wrapped cpr version 1.3.0 in meson build

### DIFF
--- a/cpr/meson.build
+++ b/cpr/meson.build
@@ -1,0 +1,14 @@
+cpr_src = files(
+'auth.cpp',
+'cookies.cpp',
+'cprtypes.cpp',
+'digest.cpp',
+'error.cpp',
+'multipart.cpp',
+'parameters.cpp',
+'payload.cpp',
+'proxies.cpp',
+'session.cpp',
+'ssl_options.cpp',
+'timeout.cpp',
+'util.cpp')

--- a/meson.build
+++ b/meson.build
@@ -1,12 +1,14 @@
-project('cpr', 'cpp', version : '1.3.0', license : 'MIT')
+project('cpr', 'cpp', 
+    version : '1.3.0', 
+    license : 'MIT', 
+    default_options : ['cpp_std=c++14']
+)
 
 curl_dep = dependency('libcurl')
-
-comp_flags=['-std=c++14']
-link_flags=['-lpthread']
+thread_dep = dependency('threads')
 
 includes = include_directories('include')
 subdir('cpr')
 
-cpr_lib = shared_library('cpr', include_directories: includes, sources: cpr_src, dependencies: curl_dep)
+cpr_lib = library('cpr', include_directories: includes, sources: cpr_src, dependencies: [curl_dep, thread_dep])
 cpr_dep = declare_dependency(include_directories: includes, link_with: cpr_lib)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,12 @@
+project('cpr', 'cpp', version : '1.3.0', license : 'MIT')
+
+curl_dep = dependency('libcurl')
+
+comp_flags=['-std=c++14']
+link_flags=['-lpthread']
+
+includes = include_directories('include')
+subdir('cpr')
+
+cpr_lib = shared_library('cpr', include_directories: includes, sources: cpr_src, dependencies: curl_dep)
+cpr_dep = declare_dependency(include_directories: includes, link_with: cpr_lib)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = cpr-1.3.0
+
+source_url = https://github.com/whoshuu/cpr/archive/1.3.0.zip 
+source_filename = cpr-1.3.0.zip
+source_hash = fc3efdb70fe8bd26f81d48336e1af25b8cd4acfdfb4ef9c6a817363467fe4f6b


### PR DESCRIPTION
Hello,
this is my initial commit of meson build support for the cpr library.
Currently it depends on curl and exports a dependency cpr_dep. The projects tests where not wrapped.
project() has specified version and license info.
